### PR TITLE
Fix(centos): Relax version constraints for compat-gcc packages

### DIFF
--- a/centos/Dockerfile
+++ b/centos/Dockerfile
@@ -6,7 +6,7 @@ SHELL ["/bin/bash", "-l", "-o", "pipefail", "-c"]
 RUN yum update -y && \
     yum -y install epel-release && \
     yum install -y make gcc g++ nkf wget perl gettext libffi-devel \
-        compat-gcc-34-3.4.6-4.1.x86_64 compat-gcc-34-c++-3.4.6-4.1.x86_64
+        compat-gcc-34 compat-gcc-34-c++
 
 # RUN yum install -y git && \
 #     git config --global http.sslVersion "tlsv1.2"


### PR DESCRIPTION
The CentOS 5 Docker build is failing because the `yum install` command is trying to install a very specific version of the `compat-gcc-34` and `compat-gcc-34-c++` packages. These specific versions are no longer available in the repositories.

This commit removes the hardcoded version and architecture from the package names, allowing yum to resolve the latest available version of the `compat-gcc-34` packages from the repository. This should fix the build failure.